### PR TITLE
Updated scripts to include jquery, popper, and js

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -76,6 +76,8 @@
             </div>
         </footer>
 
-        <!--Include Bootstrap 4's javascript code-->
-        <script type="javascript" src="{{url_for('static', filename='js/bootstrap.min.js')}}"></script>
+        <!--Include jquery, popper, and Bootstrap 4's javascript code-->
+        <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
     </body>


### PR DESCRIPTION
In order to make buttons and dropdown nav items work, jQuery and popper were needed to be added to the script. They are used in base.html since these features will be ubiquitous across all pages on the site.